### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "es6"
   ],
   "dependencies": {
-    "request": "2.61.0"
+    "request": "2.74.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
do-wrapper currently has a vulnerable dependency, introducing [Remote Memory Exposure vulnerability](https://snyk.io/vuln/npm:request:20160119) in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/matt-major/do-wrapper) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)