### PR TITLE
Fix cdnEndpointGetAll

### DIFF
--- a/src/do-wrapper.js
+++ b/src/do-wrapper.js
@@ -204,7 +204,7 @@ export default class DigitalOcean {
    */
   cdnEndpointGetAll(query, callback) {
     const options = {
-      actionPath: '/cdn/endpoints',
+      actionPath: 'cdn/endpoints',
       key: 'endpoints',
       qs: {
         tag_name: (query) ? (query.tag_name || '') : '',


### PR DESCRIPTION
Calling cdnEndpointGetAll will simply throw an exception/promise rejection. The underlying HTTP request to DO API is returning a 404. It's kind of sad that their end so literally interrupts the double slash as a route.

Fairly simple fix. None of the other actionPaths start with a slash either.