### PR TITLE
v4 Fix promise callback parameters order in RequestHelper

### DIFF
--- a/dist/request-helper.js
+++ b/dist/request-helper.js
@@ -37,7 +37,7 @@ var RequestHelper = /** @class */ (function () {
     RequestHelper.prototype.request = function (options) {
         var callback;
         var promise = new Promise(function (resolve, reject) {
-            callback = function (err, body) {
+            callback = function (body, err) {
                 if (err) {
                     reject(err);
                 }

--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -32,7 +32,7 @@ export default class RequestHelper {
         let callback;
 
         const promise = new Promise((resolve, reject) => {
-            callback = (err: any, body: any) => {
+            callback = (body: any, err: any) => {
                 if (err) {
                     reject(err);
                 } else {


### PR DESCRIPTION
I was testing the v4.0 alpha release and noticed that all api responses where returned as error by the promises : 

```js
instance.account.get().then((data) => {
    console.log(data);
}).catch((e) => {
   // This code was executed when there was no error...
    console.log('Error : '+ e);
});
```

And I noticed that the promise's callback parameters where inverted in the request() method