### PR TITLE
Fix: parsing 204 bodies

### DIFF
--- a/dist/request-helper.js
+++ b/dist/request-helper.js
@@ -58,7 +58,7 @@ var RequestHelper = /** @class */ (function () {
         var requestOptions = this.requestBuilder(options);
         got_1.default(this.apiUrl + options.actionPath, requestOptions)
             .then(function (response) {
-            callback(JSON.parse(response.body), null);
+            callback(response.statusCode === 204 ? null : JSON.parse(response.body), null);
         })
             .catch(function (error) {
             callback(null, error);

--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -56,7 +56,7 @@ export default class RequestHelper {
 
         got(this.apiUrl + options.actionPath, requestOptions)
             .then((response: any) => {
-                callback(JSON.parse(response.body), null);
+                callback(response.statusCode === 204 ? null : JSON.parse(response.body), null);
             })
             .catch((error: any) => {
                 callback(null, error);


### PR DESCRIPTION
This adds a patch for `do-wrapper` to avoid a `JSON.parse()` when the server returns 204.

Also, are you aware that your CI has been not running your tests since like v3?