### PR TITLE
Remove trailing slash from projects baseOptions

### DIFF
--- a/src/modules/projects.ts
+++ b/src/modules/projects.ts
@@ -7,7 +7,7 @@ export default class Projects extends BaseModule {
     private basePath: string = 'projects';
 
     private baseOptions: any = {
-        actionPath: `${this.basePath}/`,
+        actionPath: `${this.basePath}`,
     };
 
     constructor(pageSize: number, requestHelper: RequestHelper) {


### PR DESCRIPTION
`projects.getAll` currently throws a 404 error because of a trailing `/`.

I've also tested this against the API in postman, and the trailing slash does in fact break the request.