### PR TITLE
Fixed tags action path

### DIFF
--- a/dist/modules/tags.js
+++ b/dist/modules/tags.js
@@ -32,7 +32,7 @@ var Tags = /** @class */ (function (_super) {
         var _this = _super.call(this, pageSize, requestHelper) || this;
         _this.basePath = 'tags';
         _this.baseOptions = {
-            actionPath: _this.basePath + "/",
+            actionPath: _this.basePath,
         };
         return _this;
     }

--- a/src/modules/tags.ts
+++ b/src/modules/tags.ts
@@ -7,7 +7,7 @@ export default class Tags extends BaseModule {
     private basePath: string = 'tags';
 
     private baseOptions: any = {
-        actionPath: `${this.basePath}/`,
+        actionPath: this.basePath,
     };
 
     constructor(pageSize: number, requestHelper: RequestHelper) {


### PR DESCRIPTION
Hey @matt-major!

Great wrapper package you have there.

I've encountered an issue when trying to use the `tags` module: the `actionPath` has a trailing `/` symbol, which caused `create` and `getAll` methods to fail with `404`. For example, for the `getAll` method, the wrapper would call `https://api.digitalocean.com/v2/tags/` instead of `https://api.digitalocean.com/v2/tags`.

Removing the `/` makes sure that all of the methods work correctly (except for the issue fixed in #54).

Reference docs: https://developers.digitalocean.com/documentation/v2/#tags.

I would really appreciate it if I could get this merged! 🙌 