### PR TITLE
Fix for broken LoadBalancers.getAll function

### DIFF
--- a/dist/modules/load-balancers.js
+++ b/dist/modules/load-balancers.js
@@ -32,7 +32,7 @@ var LoadBalancers = /** @class */ (function (_super) {
         var _this = _super.call(this, pageSize, requestHelper) || this;
         _this.basePath = 'load_balancers';
         _this.baseOptions = {
-            actionPath: _this.basePath + "/",
+            actionPath: _this.basePath,
         };
         return _this;
     }

--- a/src/modules/load-balancers.ts
+++ b/src/modules/load-balancers.ts
@@ -7,7 +7,7 @@ export default class LoadBalancers extends BaseModule {
     private basePath: string = 'load_balancers';
 
     private baseOptions: any = {
-        actionPath: `${this.basePath}/`,
+        actionPath: this.basePath,
     };
 
     constructor(pageSize: number, requestHelper: RequestHelper) {


### PR DESCRIPTION
LoadBalancers.getAll() was failing with the following error:

`{ HTTPError: Response code 404 (Not Found)
    at EventEmitter.emitter.on (/app/node_modules/do-wrapper-fork/node_modules/got/dist/source/as-promise.js:118:31)
    at process._tickCallback (internal/process/next_tick.js:68:7) name: 'HTTPError' }`

Debugging this issue resulted in finding that a trailing slash in the API endpoint URL was causing the DO API to look for an ID after the trailing slash. Remove trailing slash from LoadBalancers `basePath` variable fixes this issue.

I am not sure if this was caused by an issue with the DO API itself, but this fix works for LoadBalancers in do-wrapper. I have not tested whether the LoadBalancers.create function is affected by this pull request. All other calls within the LoadBalancers module utilize a custom `actionPath` and will not be affected by this change.