### PR TITLE
Small changes

### DIFF
--- a/src/modules/domains.ts
+++ b/src/modules/domains.ts
@@ -80,11 +80,11 @@ export default class Domains extends BaseModule {
      * @param [pageSize] the number of Domains to return per page (optional)
      * @returns Promise
      */
-    public getAllRecords(domainName: string, tagName: string, includeAll: boolean = false, page: number = 1, pageSize: number = this.pageSize): Promise<any> {
+    public getAllRecords(domainName: string, type?: string, includeAll: boolean = false, page: number = 1, pageSize: number = this.pageSize): Promise<any> {
         const requestOptions = this._getBasePaginatedRequestOptions({
             actionPath: `${this.basePath}/${encodeURIComponent(domainName)}/records`,
             key: 'domain_records',
-            tagName: tagName,
+            type,
             pageSize: pageSize,
             page: page,
             includeAll: includeAll,

--- a/src/types/droplets.d.ts
+++ b/src/types/droplets.d.ts
@@ -2,13 +2,13 @@ export interface DropletCreationRequest {
     name: string;
     region: string;
     size: string;
-    image: string;
-    ssh_keys: number[];
-    backups: boolean;
-    ipv6: boolean,
-    private_networking: boolean;
-    user_data: any;
-    monitoring: boolean;
-    volumes: string[];
-    tags: string[];
+    image: string | number;
+    ssh_keys?: Array<string | number>;
+    backups?: boolean;
+    ipv6?: boolean,
+    monitoring?: boolean;
+    tags?: string[];
+    user_data?: any;
+    vpc_uuid?: string;
+    with_droplet_agent?: boolean;
 }


### PR DESCRIPTION
Some code is outdated because of changed in the DO Api.

Only changed dropletCreationRequest type & getAllRecords() Function.

private_networking is deprecated, see:
https://docs.digitalocean.com/reference/api/api-reference/#operation/create_droplet.

getAllRecords requires tag parameter wich isn't supported by DO. Changed
this to type parameter.