### PR TITLE
Update droplet args

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "do-wrapper",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "Node.js Wrapper for Digital Ocean API v2",
   "author": "Matt Major",
   "homepage": "https://github.com/matt-major/do-wrapper",

--- a/src/types/droplets.d.ts
+++ b/src/types/droplets.d.ts
@@ -6,6 +6,8 @@ export interface DropletCreationRequest {
     ssh_keys: number[];
     backups: boolean;
     ipv6: boolean;
+    /** @deprecated */
+    private_networking?: boolean;
     vpc_uuid?: string;
     user_data: any;
     monitoring: boolean;

--- a/src/types/droplets.d.ts
+++ b/src/types/droplets.d.ts
@@ -5,8 +5,8 @@ export interface DropletCreationRequest {
     image: string;
     ssh_keys: number[];
     backups: boolean;
-    ipv6: boolean,
-    private_networking: boolean;
+    ipv6: boolean;
+    vpc_uuid?: string;
     user_data: any;
     monitoring: boolean;
     volumes: string[];


### PR DESCRIPTION
Per the latest API docs, use of `private_networking` is deprecated in favour of `vpc_uuid`. This PR addresses that change.