### PR TITLE
Allow overriding digitalocean base URL.

### DIFF
--- a/src/do-wrapper.ts
+++ b/src/do-wrapper.ts
@@ -21,6 +21,10 @@ import Snapshots from './modules/snapshots';
 import Tags from './modules/tags';
 import Volumes from './modules/volumes';
 
+interface Config {
+    apiUrl: string;
+}
+
 export default class DigitalOcean {
     public account: Account;
     public actions: Actions;
@@ -43,8 +47,10 @@ export default class DigitalOcean {
     public tags: Tags;
     public volumes: Volumes;
 
-    constructor(token: string, pageSize: number = 10) {
-        const requestHelper = new RequestHelper(token);
+    constructor(token: string, pageSize: number = 10, config?: Config) {
+        const requestHelper = new RequestHelper(token, {
+            apiUrl: config?.apiUrl || ""
+        });
         this.account = new Account(pageSize, requestHelper);
         this.actions = new Actions(pageSize, requestHelper);
         this.cdn = new CDN(pageSize, requestHelper);

--- a/src/request-helper.ts
+++ b/src/request-helper.ts
@@ -5,6 +5,10 @@ interface Headers {
     [key: string]: any;
 }
 
+interface Config {
+    apiUrl: string;
+}
+
 export default class RequestHelper {
     private headers: Headers;
     private apiUrl: string;
@@ -12,15 +16,21 @@ export default class RequestHelper {
     /**
      * Request Helper
      * @param {string} token - Your Private API Token
+     * @param {Config} config - Configuration for overrides
      * @constructor
      */
-    constructor(token: string) {
+    constructor(token: string, config: Config) {
         this.headers = {
             'authorization': `Bearer ${token}`,
             'content_type': 'application/json'
         };
 
-        this.apiUrl = 'https://api.digitalocean.com/v2/';
+        let url = 'https://api.digitalocean.com/v2/';
+        if (config.apiUrl.trim().length > 0) {
+            url = config.apiUrl;
+        }
+
+        this.apiUrl = url;
     }
 
     /**


### PR DESCRIPTION
Given digitalocean shares it's open api spec, developers may choose to test their applications against mock DO servers.

Not to mention, this ability affords us the ability to write automated tests against the DO API without having to worry about accidentally provisioning infrastructure.